### PR TITLE
Implement JetLux frontend

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,21 +1,15 @@
-import { CallToAction } from '@/components/CallToAction'
-import { Faqs } from '@/components/Faqs'
-import { Hero } from '@/components/Hero'
-import { Pricing } from '@/components/Pricing'
-import { PrimaryFeatures } from '@/components/PrimaryFeatures'
+import { JetLuxHero } from '@/components/JetLuxHero'
+import { Hosts } from '@/components/Hosts'
 import { Reviews } from '@/components/Reviews'
-import { SecondaryFeatures } from '@/components/SecondaryFeatures'
+import { ContactBanner } from '@/components/ContactBanner'
 
 export default function Home() {
   return (
     <>
-      <Hero />
-      <PrimaryFeatures />
-      <SecondaryFeatures />
-      <CallToAction />
+      <JetLuxHero />
+      <Hosts />
       <Reviews />
-      <Pricing />
-      <Faqs />
+      <ContactBanner />
     </>
   )
 }

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: 'Finalize Your Booking',
+}
+
+export default function BookingPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">Finalize Your Booking</h1>
+      <form className="mt-8 grid gap-4">
+        <input className="border p-2" placeholder="Vehicle" />
+        <input className="border p-2" placeholder="Buddy" />
+        <input type="datetime-local" className="border p-2" placeholder="Start Time" />
+        <input className="border p-2" placeholder="Duration" />
+        <input type="datetime-local" className="border p-2" placeholder="End Time" />
+        <input className="border p-2" placeholder="Promo Code" />
+        <button className="mt-4 rounded bg-cyan-600 p-2 text-white" type="submit">Book Now</button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/buddies/page.tsx
+++ b/src/app/buddies/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: 'Buddies',
+}
+
+export default function BuddiesPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">Our Buddies</h1>
+      <p className="mt-4">Find the perfect guide for your next ride.</p>
+    </div>
+  )
+}

--- a/src/app/jetskis/page.tsx
+++ b/src/app/jetskis/page.tsx
@@ -1,0 +1,49 @@
+import { type Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Jet Skis – Charlies Rentals',
+}
+
+const skis = [
+  {
+    name: 'Yamaha EX Deluxe',
+    image: '',
+    available: true,
+    rate: '$120/hr',
+    speed: '50 mph',
+    riders: 2,
+    limit: '350 lbs',
+  },
+  {
+    name: 'Sea-Doo Spark Trixx',
+    image: '',
+    available: false,
+    rate: '$110/hr',
+    speed: '48 mph',
+    riders: 2,
+    limit: '330 lbs',
+  },
+]
+
+export default function JetSkisPage() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">Jet Skis</h1>
+      <ul className="mt-8 grid gap-8 sm:grid-cols-2">
+        {skis.map((ski) => (
+          <li key={ski.name} className="rounded-lg border p-4">
+            <div className="h-40 bg-gray-200 mb-4" />
+            <h2 className="text-xl font-medium">{ski.name}</h2>
+            <p className="mt-1 text-sm">Rate: {ski.rate}</p>
+            <p className="text-sm">Top Speed: {ski.speed}</p>
+            <p className="text-sm">Max Riders: {ski.riders}</p>
+            <p className="text-sm">Weight Limit: {ski.limit}</p>
+            <p className="mt-2 text-sm font-semibold">
+              {ski.available ? 'Available' : 'Currently Unavailable'}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,11 +12,10 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: {
-    template: '%s - Pocket',
-    default: 'Pocket - Invest at the perfect time.',
+    template: '%s - JetLux',
+    default: 'JetLux',
   },
-  description:
-    'By leveraging insights from our network of industry insiders, you’ll know exactly when to buy to maximize profit, and exactly when to sell to avoid painful losses.',
+  description: 'Premium water vehicle rentals in Tampa, Florida.',
 }
 
 export default function RootLayout({

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,0 +1,9 @@
+import { Reviews } from '@/components/Reviews'
+
+export const metadata = {
+  title: 'Reviews',
+}
+
+export default function ReviewsPage() {
+  return <Reviews />
+}

--- a/src/app/waiver/page.tsx
+++ b/src/app/waiver/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: 'Rental Waiver',
+}
+
+export default function WaiverPage() {
+  return (
+    <div className="prose mx-auto px-4 py-16">
+      <h1>Jet Ski Rental Waiver and Release of Liability</h1>
+      <p>Charlie&apos;s Jet Ski Rentals</p>
+      <p>Email: <a href="mailto:charles.giet@charliesjetskirentals.com">charles.giet@charliesjetskirentals.com</a></p>
+      <p>Phone: (813) 444-3746</p>
+      <h2>Risk Acknowledgment</h2>
+      <p>Riding a jet ski involves inherent risk. By proceeding you accept all responsibility for injury or damage.</p>
+      <h2>Liability Release</h2>
+      <p>You release Charlie&apos;s Jet Ski Rentals, its affiliates, ski buddies, and renters from all liability.</p>
+      <h2>Additional Terms</h2>
+      <p>Users must agree to this waiver before booking.</p>
+    </div>
+  )
+}

--- a/src/components/ContactBanner.tsx
+++ b/src/components/ContactBanner.tsx
@@ -1,0 +1,12 @@
+export function ContactBanner() {
+  return (
+    <div className="bg-gray-900 py-6 text-center text-white">
+      <p>
+        <a href="mailto:charles.giet@charliesjetskirentals.com" className="underline">
+          charles.giet@charliesjetskirentals.com
+        </a>{' '}
+        | (813) 444-3746
+      </p>
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,24 +1,7 @@
-import Image from 'next/image'
 import Link from 'next/link'
 
-import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
-import { TextField } from '@/components/Fields'
-import { Logomark } from '@/components/Logo'
 import { NavLinks } from '@/components/NavLinks'
-import qrCode from '@/images/qr-code.svg'
-
-function QrCodeBorder(props: React.ComponentPropsWithoutRef<'svg'>) {
-  return (
-    <svg viewBox="0 0 96 96" fill="none" aria-hidden="true" {...props}>
-      <path
-        d="M1 17V9a8 8 0 0 1 8-8h8M95 17V9a8 8 0 0 0-8-8h-8M1 79v8a8 8 0 0 0 8 8h8M95 79v8a8 8 0 0 1-8 8h-8"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
-    </svg>
-  )
-}
 
 export function Footer() {
   return (
@@ -26,52 +9,16 @@ export function Footer() {
       <Container>
         <div className="flex flex-col items-start justify-between gap-y-12 pt-16 pb-6 lg:flex-row lg:items-center lg:py-16">
           <div>
-            <div className="flex items-center text-gray-900">
-              <Logomark className="h-10 w-10 flex-none fill-cyan-500" />
-              <div className="ml-4">
-                <p className="text-base font-semibold">Pocket</p>
-                <p className="mt-1 text-sm">Invest at the perfect time.</p>
-              </div>
-            </div>
-            <nav className="mt-11 flex gap-8">
+            <p className="text-xl font-semibold text-gray-900">JetLux</p>
+            <p className="mt-1 text-sm text-gray-700">Luxury on the water starts here 🌊</p>
+            <nav className="mt-6 flex gap-8">
               <NavLinks />
             </nav>
           </div>
-          <div className="group relative -mx-4 flex items-center self-stretch p-4 transition-colors hover:bg-gray-100 sm:self-auto sm:rounded-2xl lg:mx-0 lg:self-auto lg:p-6">
-            <div className="relative flex h-24 w-24 flex-none items-center justify-center">
-              <QrCodeBorder className="absolute inset-0 h-full w-full stroke-gray-300 transition-colors group-hover:stroke-cyan-500" />
-              <Image src={qrCode} alt="" unoptimized />
-            </div>
-            <div className="ml-8 lg:w-64">
-              <p className="text-base font-semibold text-gray-900">
-                <Link href="#">
-                  <span className="absolute inset-0 sm:rounded-2xl" />
-                  Download the app
-                </Link>
-              </p>
-              <p className="mt-1 text-sm text-gray-700">
-                Scan the QR code to download the app from the App Store.
-              </p>
-            </div>
-          </div>
         </div>
-        <div className="flex flex-col items-center border-t border-gray-200 pt-8 pb-12 md:flex-row-reverse md:justify-between md:pt-6">
-          <form className="flex w-full justify-center md:w-auto">
-            <TextField
-              type="email"
-              aria-label="Email address"
-              placeholder="Email address"
-              autoComplete="email"
-              required
-              className="w-60 min-w-0 shrink"
-            />
-            <Button type="submit" color="cyan" className="ml-4 flex-none">
-              <span className="hidden lg:inline">Join our newsletter</span>
-              <span className="lg:hidden">Join newsletter</span>
-            </Button>
-          </form>
-          <p className="mt-6 text-sm text-gray-500 md:mt-0">
-            &copy; Copyright {new Date().getFullYear()}. All rights reserved.
+        <div className="flex flex-col items-center border-t border-gray-200 py-8">
+          <p className="text-sm text-gray-500">
+            © 2025 JetLux • Tampa, Florida
           </p>
         </div>
       </Container>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 
 import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
-import { Logo } from '@/components/Logo'
+// import { Logo } from '@/components/Logo'
 import { NavLinks } from '@/components/NavLinks'
 
 function MenuIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
@@ -61,8 +61,8 @@ export function Header() {
       <nav>
         <Container className="relative z-50 flex justify-between py-8">
           <div className="relative z-10 flex items-center gap-16">
-            <Link href="/" aria-label="Home">
-              <Logo className="h-10 w-auto" />
+            <Link href="/" aria-label="Home" className="text-xl font-semibold">
+              JetLux
             </Link>
             <div className="hidden lg:flex lg:gap-10">
               <NavLinks />
@@ -108,22 +108,16 @@ export function Header() {
                           className="absolute inset-x-0 top-0 z-0 origin-top rounded-b-2xl bg-gray-50 px-6 pt-32 pb-6 shadow-2xl shadow-gray-900/20"
                         >
                           <div className="space-y-4">
-                            <MobileNavLink href="/#features">
-                              Features
-                            </MobileNavLink>
-                            <MobileNavLink href="/#reviews">
-                              Reviews
-                            </MobileNavLink>
-                            <MobileNavLink href="/#pricing">
-                              Pricing
-                            </MobileNavLink>
-                            <MobileNavLink href="/#faqs">FAQs</MobileNavLink>
+                            <MobileNavLink href="/jetskis">Jet Skis</MobileNavLink>
+                            <MobileNavLink href="/booking">Book Now</MobileNavLink>
+                            <MobileNavLink href="/buddies">Buddies</MobileNavLink>
+                            <MobileNavLink href="/reviews">Reviews</MobileNavLink>
                           </div>
                           <div className="mt-8 flex flex-col gap-4">
                             <Button href="/login" variant="outline">
                               Log in
                             </Button>
-                            <Button href="#">Download the app</Button>
+                            <Button href="/register">Register</Button>
                           </div>
                         </PopoverPanel>
                       </>
@@ -136,7 +130,7 @@ export function Header() {
               <Button href="/login" variant="outline">
                 Log in
               </Button>
-              <Button href="#">Download</Button>
+              <Button href="/register">Register</Button>
             </div>
           </div>
         </Container>

--- a/src/components/Hosts.tsx
+++ b/src/components/Hosts.tsx
@@ -1,0 +1,27 @@
+export function Hosts() {
+  const hosts = [
+    { name: 'Charlie', bio: 'Your go-to host for unforgettable jet ski adventures.' },
+    { name: 'Danielle', bio: 'Knows every waterway around Tampa.' },
+    { name: 'Max', bio: 'Ensures safety while you have fun on the waves.' },
+  ]
+
+  return (
+    <section className="py-20" id="hosts">
+      <div className="mx-auto max-w-4xl px-4 text-center">
+        <h2 className="text-3xl font-semibold">Meet Our Hosts</h2>
+        <p className="mt-2 text-lg text-gray-600">
+          Trusted hosts who offer various rentals
+        </p>
+        <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {hosts.map((host) => (
+            <div key={host.name} className="rounded-lg bg-white p-6 shadow">
+              <div className="h-40 bg-gray-200 mb-4" />
+              <h3 className="text-xl font-medium">{host.name}</h3>
+              <p className="mt-2 text-sm text-gray-600">{host.bio}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/JetLuxHero.tsx
+++ b/src/components/JetLuxHero.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/Button'
+
+export function JetLuxHero() {
+  return (
+    <section className="relative h-[60vh] w-full overflow-hidden bg-gray-900">
+      <video
+        className="absolute inset-0 h-full w-full object-cover"
+        src="/videos/hero.mp4"
+        autoPlay
+        loop
+        muted
+      />
+      <div className="absolute inset-0 bg-black/40" />
+      <div className="relative z-10 flex h-full flex-col items-center justify-center text-center text-white px-4">
+        <h1 className="text-4xl font-bold sm:text-5xl">Premium Water Vehicle Rentals</h1>
+        <p className="mt-4 max-w-xl text-lg">
+          Experience the thrill on the water with top-tier equipment and unbeatable views.
+        </p>
+        <Button href="/booking" color="cyan" className="mt-6">
+          Book Now
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -9,10 +9,10 @@ export function NavLinks() {
   let timeoutRef = useRef<number | null>(null)
 
   return [
-    ['Features', '/#features'],
-    ['Reviews', '/#reviews'],
-    ['Pricing', '/#pricing'],
-    ['FAQs', '/#faqs'],
+    ['Jet Skis', '/jetskis'],
+    ['Book Now', '/booking'],
+    ['Buddies', '/buddies'],
+    ['Reviews', '/reviews'],
   ].map(([label, href], index) => (
     <Link
       key={label}

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -282,11 +282,8 @@ export function Reviews() {
           id="reviews-title"
           className="text-3xl font-medium tracking-tight text-gray-900 sm:text-center"
         >
-          Everyone is changing their life with Pocket.
+          Customer Reviews – What People Are Saying
         </h2>
-        <p className="mt-2 text-lg text-gray-600 sm:text-center">
-          Thousands of people have doubled their net-worth in the last 30 days.
-        </p>
         <ReviewGrid />
       </Container>
     </section>


### PR DESCRIPTION
## Summary
- customize header and navigation
- add new hero, hosts, and contact banner components
- simplify footer text
- add pages for jet skis, booking, buddies, reviews, and waiver
- adjust metadata and remove unused sections

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881630d82a48323ad596ccbafa3b7a0